### PR TITLE
Add raw filter to qrcode.html.twig.

### DIFF
--- a/templates/partials/qrcode.html.twig
+++ b/templates/partials/qrcode.html.twig
@@ -1,1 +1,1 @@
-{{- qrcode_image_element(text, parameters) -}}
+{{- qrcode_image_element(text, parameters) | raw -}}


### PR DESCRIPTION
After Grav 1.7.19, twig output is filtered by default (https://github.com/getgrav/grav/issues/3091). Adding the raw filter enables this plugin to work as expected.